### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/upload/strategy/secure.py
+++ b/upload/strategy/secure.py
@@ -22,10 +22,10 @@ class Secure:
 
         for file in os_module.listdir(request.localPath):
             if fnmatch_module.fnmatch(file, request.prefix + request.pattern):
-                self.logging.info('Uploading file %s...' % file)
+                self.logging.info('Uploading file {0!s}...'.format(file))
                 sftp.put(request.localPath + file, request.remotePath + '/' + file)
 
-        self.logging.info('Files has been successfully uploaded to %s' % (request.connectionInfo['host']))
+        self.logging.info('Files has been successfully uploaded to {0!s}'.format((request.connectionInfo['host'])))
 
         sftp.close()
 

--- a/upload/strategy/unsecure.py
+++ b/upload/strategy/unsecure.py
@@ -25,10 +25,10 @@ class Unsecure:
 
         for file in os_module.listdir(request.localPath):
             if fnmatch_module.fnmatch(file, request.prefix + request.pattern):
-                self.logging.info('Uploading file %s...' % file)
-                ftp.storlines('STOR %s' % file, open_module('%s%s' % (request.localPath, file), 'r'))
+                self.logging.info('Uploading file {0!s}...'.format(file))
+                ftp.storlines('STOR {0!s}'.format(file), open_module('{0!s}{1!s}'.format(request.localPath, file), 'r'))
 
-        self.logging.info('Files has been successfully uploaded to %s' % (request.connectionInfo['host']))
+        self.logging.info('Files has been successfully uploaded to {0!s}'.format((request.connectionInfo['host'])))
 
         ftp.quit()
         return True


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:acostasg:upload?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:acostasg:upload?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
